### PR TITLE
feat: add About tab to Settings dialog with font credits

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-electron_mirror=https://npmmirror.com/mirrors/electron/
-electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leavepad",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Leavepad is a multi-platform notepad. focuses on writing memos.",
   "license": "MIT",
   "type": "module",
@@ -68,7 +68,7 @@
     "autoprefixer": "^10.4.24",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "electron": "^40.1.0",
+    "electron": "^41.1.1",
     "electron-builder": "~26.5.0",
     "electron-vite": "^5.0.0",
     "eslint": "^9.14.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -25,8 +25,16 @@ export function initAutoUpdater(mainWindow: BrowserWindow) {
   autoUpdater.autoDownload = true // バックグラウンドで自動DL
   autoUpdater.autoInstallOnAppQuit = true // 終了時に自動インストール
 
+  autoUpdater.on('checking-for-update', () => {
+    mainWindow.webContents.send('update-checking')
+  })
+
   autoUpdater.on('update-available', (info) => {
     mainWindow.webContents.send('update-available', info)
+  })
+
+  autoUpdater.on('update-not-available', () => {
+    mainWindow.webContents.send('update-not-available')
   })
 
   autoUpdater.on('update-downloaded', (info) => {
@@ -35,6 +43,7 @@ export function initAutoUpdater(mainWindow: BrowserWindow) {
 
   autoUpdater.on('error', (err) => {
     console.error('AutoUpdater error:', err)
+    mainWindow.webContents.send('update-error', err.message)
   })
 
   // 起動時にチェック

--- a/src/main/ipcHandles.ts
+++ b/src/main/ipcHandles.ts
@@ -147,4 +147,13 @@ export const registerIpcHandles = (ipcMain, mainWindow: BrowserWindow): void => 
   ipcMain.on('get-app-version', (event) => {
     event.returnValue = app.getVersion()
   })
+
+  // Trigger update check from renderer (e.g. About tab)
+  ipcMain.on('check-for-updates-now', () => {
+    if (!app.isPackaged) {
+      mainWindow.webContents.send('update-error', 'dev')
+      return
+    }
+    autoUpdater.checkForUpdates()
+  })
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -19,6 +19,7 @@ declare global {
       updateAppState: (appState: AppState) => void
       installUpdate: () => void
       getAppVersion: () => string
+      checkForUpdates: () => void
     }
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -49,6 +49,9 @@ const api = {
   },
   getAppVersion: (): string => {
     return ipcRenderer.sendSync('get-app-version')
+  },
+  checkForUpdates: (): void => {
+    ipcRenderer.send('check-for-updates-now')
   }
 }
 

--- a/src/renderer/src/components/global-settings-tabs.tsx
+++ b/src/renderer/src/components/global-settings-tabs.tsx
@@ -1,4 +1,5 @@
 import * as monaco from 'monaco-editor'
+import { useEffect, useState } from 'react'
 
 import { cn } from '@renderer/lib/utils'
 import { Button, buttonVariants } from './ui/button'
@@ -20,6 +21,153 @@ import { useAtom } from 'jotai'
 import { notesAtom } from '@renderer/lib/atoms/notes'
 import { useTranslation } from 'react-i18next'
 import { ScrollArea } from './ui/scroll-area'
+import { Separator } from './ui/separator'
+import appIcon from '../../../../resources/icon.png'
+
+type UpdateStatus = 'checking' | 'up-to-date' | 'available' | 'downloaded' | 'error'
+
+const fontCredits = [
+  {
+    name: 'Geist Sans / Geist Mono',
+    copyright: 'Copyright (c) 2023 Vercel, in collaboration with basement.studio',
+    url: 'https://github.com/vercel/geist-font'
+  },
+  {
+    name: '白源 (HackGen)',
+    copyright: 'Copyright (c) 2019 Yuko OTAWARA',
+    url: 'https://github.com/yuru7/HackGen'
+  },
+  {
+    name: 'Noto Sans JP',
+    copyright: 'Copyright 2014-2021 Adobe',
+    url: 'https://fonts.google.com/noto/specimen/Noto+Sans+JP'
+  },
+  {
+    name: 'NOTONOTO',
+    copyright: 'Copyright (c) 2024 Yuko Otawara',
+    url: 'https://github.com/yuru7/NOTONOTO'
+  },
+  {
+    name: 'Noto Color Emoji',
+    copyright: 'Copyright 2021 Google Inc.',
+    url: 'https://fonts.google.com/noto/specimen/Noto+Color+Emoji'
+  }
+]
+
+const AboutTabContent = () => {
+  const { t } = useTranslation()
+  const [version] = useState(() => window.api.getAppVersion())
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('checking')
+  const [latestVersion, setLatestVersion] = useState('')
+  const [isDevError, setIsDevError] = useState(false)
+
+  useEffect(() => {
+    window.api.checkForUpdates()
+
+    const onChecking = () => setUpdateStatus('checking')
+    const onNotAvailable = () => setUpdateStatus('up-to-date')
+    const onAvailable = (_e, info: { version: string }) => {
+      setUpdateStatus('available')
+      setLatestVersion(info.version)
+    }
+    const onDownloaded = (_e, info: { version: string }) => {
+      setUpdateStatus('downloaded')
+      setLatestVersion(info.version)
+    }
+    const onError = (_e, msg: string) => {
+      setIsDevError(msg === 'dev')
+      setUpdateStatus('error')
+    }
+
+    window.electron.ipcRenderer.on('update-checking', onChecking)
+    window.electron.ipcRenderer.on('update-not-available', onNotAvailable)
+    window.electron.ipcRenderer.on('update-available', onAvailable)
+    window.electron.ipcRenderer.on('update-downloaded', onDownloaded)
+    window.electron.ipcRenderer.on('update-error', onError)
+
+    return () => {
+      window.electron.ipcRenderer.removeListener('update-checking', onChecking)
+      window.electron.ipcRenderer.removeListener('update-not-available', onNotAvailable)
+      window.electron.ipcRenderer.removeListener('update-available', onAvailable)
+      window.electron.ipcRenderer.removeListener('update-downloaded', onDownloaded)
+      window.electron.ipcRenderer.removeListener('update-error', onError)
+    }
+  }, [])
+
+  const renderUpdateStatus = () => {
+    switch (updateStatus) {
+      case 'checking':
+        return (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            <span>{t('about.checking')}</span>
+          </div>
+        )
+      case 'up-to-date':
+        return <p className="text-sm text-green-600">{t('about.upToDate')}</p>
+      case 'available':
+        return (
+          <p className="text-sm text-blue-500">{t('about.available', { version: latestVersion })}</p>
+        )
+      case 'downloaded':
+        return (
+          <div className="flex items-center gap-2 flex-wrap">
+            <p className="text-sm text-green-600">{t('about.downloaded', { version: latestVersion })}</p>
+            <Button size="sm" onClick={() => window.api.installUpdate()}>
+              {t('restartAndUpdate')}
+            </Button>
+          </div>
+        )
+      case 'error':
+        return (
+          <p className="text-sm text-muted-foreground">
+            {isDevError ? t('about.devError') : t('about.error')}
+          </p>
+        )
+    }
+  }
+
+  return (
+    <TabsContent value="about" className="p-1">
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col items-center gap-3 pt-2">
+          <img src={appIcon} className="w-20 h-20 rounded-2xl" alt="Leavepad" />
+          <div className="text-center">
+            <h2 className="text-xl font-semibold">Leavepad</h2>
+            <p className="text-sm text-muted-foreground mt-1">Version {version}</p>
+          </div>
+          <div>{renderUpdateStatus()}</div>
+        </div>
+
+        <Separator />
+
+        <div className="flex flex-col gap-2">
+          <p className="text-sm font-medium">{t('about.fontCredits')}</p>
+          <div className="flex flex-col items-center gap-5">
+            {fontCredits.map((font) => (
+              <div key={font.name} className="text-center space-y-0.5">
+                <p className="text-sm font-semibold font-mono">{font.name}</p>
+                <p className="text-xs text-muted-foreground">{font.copyright}</p>
+                <p className="text-xs text-muted-foreground">SIL Open Font License 1.1</p>
+                <a
+                  href={font.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs text-blue-500 hover:underline"
+                >
+                  {font.url}
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </TabsContent>
+  )
+}
 
 const LanguageComboboxForm = ({ form, field }) => {
   const languages = monaco.languages.getLanguages()
@@ -325,6 +473,9 @@ const GlobalSettingsTabs = ({ settingsForm }) => {
           <TabsTrigger value="editor" className="grow">
             {t('globalSettingsGroup.editor')}
           </TabsTrigger>
+          <TabsTrigger value="about" className="grow">
+            {t('about.title')}
+          </TabsTrigger>
         </TabsList>
       </div>
       <div className="grow h-full overflow-y-auto">
@@ -332,6 +483,7 @@ const GlobalSettingsTabs = ({ settingsForm }) => {
           <GeneralTabsContent settingsForm={settingsForm} />
           <NotesTabsContent settingsForm={settingsForm} />
           <EditorTabsContent settingsForm={settingsForm} />
+          <AboutTabContent />
         </ScrollArea>
       </div>
     </Tabs>

--- a/src/renderer/src/i18n/english.json
+++ b/src/renderer/src/i18n/english.json
@@ -33,6 +33,16 @@
   "searchLanguage": "Search language...",
   "noLanguageFound": "No language found",
   "defaultLanguage": "Default",
+  "about": {
+    "title": "About",
+    "checking": "Checking for updates...",
+    "upToDate": "✓ Up to date",
+    "available": "↑ v{{version}} available (downloading...)",
+    "downloaded": "✓ v{{version}} ready to install",
+    "devError": "— Not available in development",
+    "error": "✗ Failed to check for updates",
+    "fontCredits": "Font Credits"
+  },
   "globalSettingsGroup": {
     "save": "Save",
     "cancel": "Cancel",

--- a/src/renderer/src/i18n/japanese.json
+++ b/src/renderer/src/i18n/japanese.json
@@ -33,6 +33,16 @@
   "searchLanguage": "言語を検索...",
   "noLanguageFound": "言語が見つかりません",
   "defaultLanguage": "デフォルト",
+  "about": {
+    "title": "About",
+    "checking": "アップデートを確認中...",
+    "upToDate": "✓ 最新版です",
+    "available": "↑ v{{version}} が利用可能です（ダウンロード中...）",
+    "downloaded": "✓ v{{version}} の準備ができました",
+    "devError": "— 開発環境では確認できません",
+    "error": "✗ 確認中にエラーが発生しました",
+    "fontCredits": "Font Credits"
+  },
   "globalSettingsGroup": {
     "save": "保存",
     "cancel": "キャンセル",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,10 +2577,10 @@ electron-vite@^5.0.0:
     magic-string "^0.30.19"
     picocolors "^1.1.1"
 
-electron@^40.1.0:
-  version "40.8.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-40.8.5.tgz#a7e459a2eee35bd02c32da87170c920383656c4d"
-  integrity sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A==
+electron@^41.1.1:
+  version "41.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-41.1.1.tgz#ec2016ad886b4377a4b643fa34fe9cbcd8d7f015"
+  integrity sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^24.9.0"


### PR DESCRIPTION
- Add About tab to GlobalSettingsTabs with app icon, version, and auto-update status
- Add font credits section (Geist, HackGen, Noto Sans JP, NOTONOTO, Noto Color Emoji)
- Add check-for-updates-now IPC handler, expose checkForUpdates() via preload
- Add i18n keys for About tab in English and Japanese
- Bump version to 1.9.0, update Electron to ^41.1.1