### PR TITLE
feat: improve tab UX and add editor settings

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -325,6 +325,29 @@ function App(): JSX.Element {
         setRenamingNoteId(currentNote.id)
       }
 
+      // Ctrl+W: Close active tab
+      if (isMod && e.key === 'w') {
+        e.preventDefault()
+        if (currentNote) {
+          onTabCloseClick(currentNote.id)
+        }
+      }
+
+      // Ctrl+Tab / Ctrl+Shift+Tab: Switch tabs
+      if (isMod && e.key === 'Tab') {
+        e.preventDefault()
+        if (noteTabs.length > 1 && currentNote) {
+          const currentIndex = noteTabs.findIndex((tab) => tab.id === currentNote.id)
+          if (currentIndex !== -1) {
+            const nextIndex = e.shiftKey
+              ? (currentIndex - 1 + noteTabs.length) % noteTabs.length
+              : (currentIndex + 1) % noteTabs.length
+            const note = notes.find((n) => n.id === noteTabs[nextIndex].id)
+            if (note) setCurrentNote(note)
+          }
+        }
+      }
+
       // Escape: close search modal
       if (e.key === 'Escape' && isSearchOpen) {
         setIsSearchOpen(false)
@@ -334,7 +357,7 @@ function App(): JSX.Element {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [AddNote, renamingNoteId, isSearchOpen, currentNote])
+  }, [AddNote, renamingNoteId, isSearchOpen, currentNote, noteTabs, notes, setCurrentNote])
 
   const onTabClick = (tabId: string) => {
     const note = notes.find((note) => note.id === tabId)

--- a/src/renderer/src/components/global-settings-tabs.tsx
+++ b/src/renderer/src/components/global-settings-tabs.tsx
@@ -166,6 +166,18 @@ const EditorTabsContent = ({ settingsForm }) => {
 
           <FormField
             control={settingsForm.control}
+            name="editorOptions.lineHeight"
+            render={({ field }) => (
+              <FormItem className="flex flex-col">
+                <FormLabel>{t('globalSettingsGroup.lineHeight')}</FormLabel>
+                <Input {...field} />
+                <FormDescription>{t('globalSettingsGroup.lineHeightDescription')}</FormDescription>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={settingsForm.control}
             name="editorOptions.fontFamily"
             render={({ field }) => (
               <FormItem className="flex flex-col">
@@ -282,6 +294,46 @@ const EditorTabsContent = ({ settingsForm }) => {
                   />
                 </FormControl>
                 <FormDescription>{t('globalSettingsGroup.wordWrapDescription')}</FormDescription>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={settingsForm.control}
+            name="editorOptions.lineNumbers"
+            render={({ field }) => (
+              <FormItem className="flex flex-col">
+                <FormLabel>{t('globalSettingsGroup.lineNumbers')}</FormLabel>
+                <FormControl>
+                  <Switch
+                    checked={field.value === 'on'}
+                    onCheckedChange={(checked) => {
+                      field.onChange(checked ? 'on' : 'off')
+                    }}
+                  />
+                </FormControl>
+                <FormDescription>{t('globalSettingsGroup.lineNumbersDescription')}</FormDescription>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={settingsForm.control}
+            name="editorOptions.renderWhitespace"
+            render={({ field }) => (
+              <FormItem className="flex flex-col">
+                <FormLabel>{t('globalSettingsGroup.renderWhitespace')}</FormLabel>
+                <FormControl>
+                  <select
+                    className={cn(buttonVariants({ variant: 'outline' }), 'w-full font-normal')}
+                    {...field}
+                  >
+                    <option value="none">{t('globalSettingsGroup.renderWhitespaceNone')}</option>
+                    <option value="boundary">{t('globalSettingsGroup.renderWhitespaceBoundary')}</option>
+                    <option value="selection">{t('globalSettingsGroup.renderWhitespaceSelection')}</option>
+                    <option value="trailing">{t('globalSettingsGroup.renderWhitespaceTrailing')}</option>
+                    <option value="all">{t('globalSettingsGroup.renderWhitespaceAll')}</option>
+                  </select>
+                </FormControl>
+                <FormDescription>{t('globalSettingsGroup.renderWhitespaceDescription')}</FormDescription>
               </FormItem>
             )}
           />

--- a/src/renderer/src/components/note-tabs.tsx
+++ b/src/renderer/src/components/note-tabs.tsx
@@ -2,7 +2,8 @@ import useHorizontalScroll from '@renderer/lib/useHorizontalScroll'
 import { ScrollArea, ScrollBar } from './ui/scroll-area'
 import { Tabs, TabsList, TabsTrigger } from './ui/tabs'
 import { Button } from './ui/button'
-import { useState } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
+import { useEffect, useState } from 'react'
 
 function NoteTabs({
   noteTabs,
@@ -16,6 +17,12 @@ function NoteTabs({
   const [draggedTabId, setDraggedTabId] = useState<string | null>(null)
   const [dragOverTabId, setDragOverTabId] = useState<string | null>(null)
 
+  useEffect(() => {
+    if (!activeTabId) return
+    const el = document.querySelector(`[data-tab-id="${activeTabId}"]`) as HTMLElement | null
+    el?.scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'nearest' })
+  }, [activeTabId])
+
   if (noteTabs == null) {
     return <></>
   }
@@ -28,11 +35,9 @@ function NoteTabs({
     setDraggedTabId(tabId)
     e.dataTransfer.effectAllowed = 'move'
 
-    // Create a custom drag image (ghost)
     const target = e.currentTarget as HTMLElement
     const clone = target.cloneNode(true) as HTMLElement
 
-    // Style the clone for the drag preview
     clone.style.position = 'absolute'
     clone.style.top = '-9999px'
     clone.style.left = '-9999px'
@@ -47,14 +52,12 @@ function NoteTabs({
 
     document.body.appendChild(clone)
 
-    // Calculate offset from the click position within the element
     const rect = target.getBoundingClientRect()
     const offsetX = e.clientX - rect.left
     const offsetY = e.clientY - rect.top
 
     e.dataTransfer.setDragImage(clone, offsetX, offsetY)
 
-    // Remove the clone after drag starts
     setTimeout(() => {
       document.body.removeChild(clone)
     }, 0)
@@ -91,7 +94,6 @@ function NoteTabs({
       return
     }
 
-    // Create new array with reordered tabs
     const newTabs = [...noteTabs]
     const [removed] = newTabs.splice(draggedIndex, 1)
     newTabs.splice(targetIndex, 0, removed)
@@ -113,6 +115,7 @@ function NoteTabs({
           {tabs.map((tab) => {
             const isDragging = draggedTabId === tab
             const isDragOver = dragOverTabId === tab
+            const tabName = noteTabs.find((nt) => nt.id === tab).name
 
             return (
               <TabsTrigger
@@ -125,7 +128,7 @@ function NoteTabs({
                 onDragLeave={handleDragLeave}
                 onDrop={(e) => handleDrop(e, tab)}
                 onDragEnd={handleDragEnd}
-                className={`flex items-center gap-3 h-full rounded-none rounded-t-sm border border-b-0 transition-all ${
+                className={`flex items-center gap-3 h-full rounded-none rounded-t-sm border border-b-0 transition-all overflow-hidden min-w-0 flex-1 max-w-[30%] ${
                   isDragging ? 'opacity-40 bg-muted' : ''
                 } ${isDragOver ? 'border-l-4 border-l-blue-500 shadow-lg' : ''}`}
                 style={{
@@ -133,11 +136,16 @@ function NoteTabs({
                 }}
                 asChild
               >
-                <div>
-                  <button className="grow">
-                    {noteTabs.find((noteTabs) => noteTabs.id === tab).name}
-                  </button>
-                  <div className="flex h-full items-center">
+                <div onAuxClick={(e) => { if (e.button === 1) onTabCloseClick(tab) }}>
+                  <Tooltip delayDuration={700}>
+                    <TooltipTrigger asChild>
+                      <button className="grow min-w-0 truncate text-left">
+                        {tabName}
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>{tabName}</TooltipContent>
+                  </Tooltip>
+                  <div className="flex h-full items-center shrink-0">
                     <Button
                       variant="ghost"
                       className="flex items-center w-4 h-4 rounded-none"

--- a/src/renderer/src/i18n/english.json
+++ b/src/renderer/src/i18n/english.json
@@ -83,6 +83,17 @@
     "useTabStops": "useTabStops",
     "useTabStopsDescription": "Inserting and deleting whitespace follows tab stops.",
     "wordWrap": "wordWrap",
-    "wordWrapDescription": "Lines will wrap according to the wordWrap setting."
+    "wordWrapDescription": "Lines will wrap according to the wordWrap setting.",
+    "lineNumbers": "Line numbers",
+    "lineNumbersDescription": "Show line numbers in the editor.",
+    "lineHeight": "Line height",
+    "lineHeightDescription": "Line height in pixels. 0 uses the default.",
+    "renderWhitespace": "Show whitespace",
+    "renderWhitespaceDescription": "Controls which whitespace characters (spaces, tabs) are rendered as visible symbols.",
+    "renderWhitespaceNone": "None",
+    "renderWhitespaceBoundary": "Boundary",
+    "renderWhitespaceSelection": "Selection",
+    "renderWhitespaceTrailing": "Trailing",
+    "renderWhitespaceAll": "All"
   }
 }

--- a/src/renderer/src/i18n/japanese.json
+++ b/src/renderer/src/i18n/japanese.json
@@ -83,6 +83,17 @@
     "useTabStops": "useTabStops",
     "useTabStopsDescription": "空白の挿入や削除はタブ位置に従って行われます。",
     "wordWrap": "wordWrap",
-    "wordWrapDescription": "行は、wordWrap の設定に従って折り返します。"
+    "wordWrapDescription": "行は、wordWrap の設定に従って折り返します。",
+    "lineNumbers": "行番号",
+    "lineNumbersDescription": "エディタに行番号を表示します。",
+    "lineHeight": "行の高さ",
+    "lineHeightDescription": "行の高さをピクセルで指定します。0 はデフォルト値を使用します。",
+    "renderWhitespace": "ホワイトスペースの可視化",
+    "renderWhitespaceDescription": "どの空白文字を記号で表示するかを設定します。",
+    "renderWhitespaceNone": "表示しない",
+    "renderWhitespaceBoundary": "単語境界のみ",
+    "renderWhitespaceSelection": "選択範囲のみ",
+    "renderWhitespaceTrailing": "末尾のみ",
+    "renderWhitespaceAll": "すべて表示"
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,8 @@ export type ConfigurableMonacoEditorOptions =
   | 'automaticLayout'
   | 'language'
   | 'insertSpaces'
+  | 'lineHeight'
+  | 'lineNumbers'
   | 'minimap'
   | 'padding'
   | 'quickSuggestions'
@@ -57,6 +59,8 @@ export const defaultNoteEditorSettings: NoteEditorSettings = {
     },
     tabSize: 2,
     useTabStops: false,
+    lineNumbers: 'on',
+    lineHeight: 0,
     wordWrap: 'off',
     fontSize: 14,
     fontFamily:


### PR DESCRIPTION
- Add Ctrl+W (close tab), Ctrl+Tab/Shift+Tab (switch tabs)
- Add middle-click to close tab
- Auto-scroll active tab into view on tab change
- Limit tab width with truncation and tooltip (CSS flex, max 30%)
- Add lineNumbers toggle (default: on)
- Add lineHeight input
- Add renderWhitespace select (none/boundary/selection/trailing/all, default: all)