### PR TITLE
fix: sync app menu and shortcuts on macOS

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      os:
+        description: 'Target OS'
+        required: true
+        default: 'macos-latest'
+        type: choice
+        options:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
 
 jobs:
   release:
@@ -11,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: ${{ github.event_name == 'workflow_dispatch' && fromJson(format('["{0}"]', inputs.os)) || fromJson('["macos-latest", "ubuntu-latest", "windows-latest"]') }}
 
     steps:
       - name: Check out Git repository
@@ -48,6 +59,17 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           yarn build:linux
+      - name: Upload artifacts (manual build)
+        uses: actions/upload-artifact@v4
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          name: leavepad-${{ matrix.os }}
+          path: |
+            dist/*.zip
+            dist/*.dmg
+            dist/*.exe
+            dist/*.snap
+            dist/*.AppImage
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,6 +56,7 @@ const menuTranslations: Record<string, Record<string, string>> = {
 
 function buildAppMenu(language: string = 'english'): void {
   const t = menuTranslations[language] ?? menuTranslations.english
+  const isMac = process.platform === 'darwin'
   const template: Electron.MenuItemConstructorOptions[] = [
     {
       label: t.file,
@@ -63,7 +64,7 @@ function buildAppMenu(language: string = 'english'): void {
         {
           label: t.newNote,
           accelerator: 'CmdOrCtrl+N',
-          registerAccelerator: false,
+          registerAccelerator: isMac,
           click: () => mainWindow.webContents.send('menu-new-note')
         },
         {
@@ -73,14 +74,14 @@ function buildAppMenu(language: string = 'english'): void {
         {
           label: t.jsonFormatter,
           accelerator: 'CmdOrCtrl+Shift+J',
-          registerAccelerator: false,
+          registerAccelerator: isMac,
           click: () => mainWindow.webContents.send('menu-open-json-formatter')
         },
         { type: 'separator' },
         {
           label: t.settings,
           accelerator: 'CmdOrCtrl+,',
-          registerAccelerator: false,
+          registerAccelerator: isMac,
           click: () => mainWindow.webContents.send('menu-open-settings')
         },
         { type: 'separator' },
@@ -93,13 +94,13 @@ function buildAppMenu(language: string = 'english'): void {
         {
           label: t.findInNotes,
           accelerator: 'CmdOrCtrl+Shift+F',
-          registerAccelerator: false,
+          registerAccelerator: isMac,
           click: () => mainWindow.webContents.send('menu-find-in-notes')
         },
         {
           label: t.findInEditor,
           accelerator: 'CmdOrCtrl+F',
-          registerAccelerator: false,
+          registerAccelerator: isMac,
           click: () => mainWindow.webContents.send('menu-find-in-editor')
         }
       ]
@@ -182,9 +183,20 @@ function createWindow(): void {
     }
   })
 
-  if (isNonMac) {
-    buildAppMenu()
+  buildAppMenu()
+  ipcMain.on('update-menu-language', (_, language: string) => buildAppMenu(language))
 
+  if (!isNonMac) {
+    mainWindow.webContents.on('before-input-event', (event, input) => {
+      if (input.type !== 'keyDown' || !input.meta || !input.shift) return
+      if (input.code === 'KeyF') {
+        event.preventDefault()
+        mainWindow.webContents.send('menu-find-in-notes')
+      }
+    })
+  }
+
+  if (isNonMac) {
     mainWindow.on('maximize', () => mainWindow.webContents.send('maximize-changed', true))
     mainWindow.on('unmaximize', () => mainWindow.webContents.send('maximize-changed', false))
 
@@ -197,7 +209,6 @@ function createWindow(): void {
     })
     ipcMain.on('close-window', () => mainWindow.close())
     ipcMain.handle('is-maximized', () => mainWindow.isMaximized())
-    ipcMain.on('update-menu-language', (_, language: string) => buildAppMenu(language))
   }
 
   if (appStateData.windowX != null && appStateData.windowY != null) {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -314,7 +314,7 @@ function App(): JSX.Element {
         window.api.openJsonFormatter()
       }
 
-      // Ctrl+Shift+F: Find in Notes
+      // Ctrl+Shift+F / Cmd+Shift+F: Find in Notes
       if (isMod && e.shiftKey && e.key === 'F') {
         e.preventDefault()
         setIsSearchOpen(true)


### PR DESCRIPTION
- Call buildAppMenu() on all platforms so Mac gets the custom menu
- Register update-menu-language handler on Mac for language sync
- Set registerAccelerator: true on Mac so menu shortcuts display correctly
- Add before-input-event handler to capture Cmd+Shift+F before Monaco intercepts it
- Add workflow_dispatch to GitHub Actions for manual Mac builds