### PR TITLE
fix: restore cut/copy/paste shortcuts in Monaco on macOS

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -91,6 +91,18 @@ function buildAppMenu(language: string = 'english'): void {
     {
       label: t.edit,
       submenu: [
+        ...(isMac
+          ? [
+              { role: 'undo' as const },
+              { role: 'redo' as const },
+              { type: 'separator' as const },
+              { role: 'cut' as const },
+              { role: 'copy' as const },
+              { role: 'paste' as const },
+              { role: 'selectAll' as const },
+              { type: 'separator' as const }
+            ]
+          : []),
         {
           label: t.findInNotes,
           accelerator: 'CmdOrCtrl+Shift+F',


### PR DESCRIPTION
Add standard edit roles (cut, copy, paste, undo, redo, selectAll) to the Edit menu on macOS. Without these roles, macOS does not pass Cmd+X/C/V to web contents when a custom app menu is set.