### PR TITLE
feat: add file associations and handle single instance file opening

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,22 @@ files:
   - "!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}"
 asarUnpack:
   - resources/**
+fileAssociations:
+  - ext:
+      - txt
+      - md
+      - json
+      - js
+      - ts
+      - tsx
+      - jsx
+      - css
+      - html
+      - log
+      - yml
+      - yaml
+    name: Text Document
+    role: Editor
 win:
   executableName: leavepad
 nsis:
@@ -22,7 +38,7 @@ mac:
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
-    - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
+    - NSMicrophoneUsageDescription: Application requests access to the user's Microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: true
@@ -52,3 +68,4 @@ publish:
   repo: leavepad
 electronDownload:
   mirror: https://npmmirror.com/mirrors/electron/
+

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,299 +16,344 @@ import { registerJsonFormatterWindowHandlers } from './jsonFormatterWindow'
 import { dbInstance } from './db_singleton'
 
 let mainWindow: BrowserWindow
+const filesToOpen: string[] = []
 
-const menuTranslations: Record<string, Record<string, string>> = {
-  english: {
-    file: 'File',
-    newNote: 'New Note',
-    fileEditor: 'File Editor',
-    jsonFormatter: 'JSON Formatter',
-    settings: 'Settings',
-    edit: 'Edit',
-    findInNotes: 'Find in Notes',
-    findInEditor: 'Find in Editor',
-    view: 'View',
-    reload: 'Reload',
-    forceReload: 'Force Reload',
-    toggleDevTools: 'Toggle Developer Tools',
-    help: 'Help',
-    checkForUpdates: 'Check for Updates',
-    about: 'About'
-  },
-  japanese: {
-    file: 'ファイル',
-    newNote: 'ノートを追加',
-    fileEditor: 'ファイルエディタ',
-    jsonFormatter: 'JSON Formatter',
-    settings: 'グローバル設定',
-    edit: '編集',
-    findInNotes: 'ノートを検索',
-    findInEditor: 'エディタ内を検索',
-    view: '表示',
-    reload: '再読み込み',
-    forceReload: '強制再読み込み',
-    toggleDevTools: '開発者ツール',
-    help: 'ヘルプ',
-    checkForUpdates: 'アップデートを確認',
-    about: 'このアプリについて'
+// Single Instance Lock
+const gotTheLock = app.requestSingleInstanceLock()
+
+if (!gotTheLock) {
+  app.quit()
+} else {
+  app.on('second-instance', (_event, commandLine) => {
+    // Someone tried to run a second instance, we should focus our window.
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.focus()
+
+      // Handle files passed via command line from second instance (Windows/Linux)
+      const fileToOpen = commandLine.find((arg, i) => i > 0 && !arg.startsWith('-'))
+      if (fileToOpen) {
+        createFileEditorWindow(fileToOpen)
+      }
+    }
+  })
+
+  // Handle files opened via Finder/drag-and-drop on macOS
+  app.on('open-file', (event, path) => {
+    event.preventDefault()
+    if (app.isReady()) {
+      createFileEditorWindow(path)
+    } else {
+      filesToOpen.push(path)
+    }
+  })
+
+  const menuTranslations: Record<string, Record<string, string>> = {
+    english: {
+      file: 'File',
+      newNote: 'New Note',
+      fileEditor: 'File Editor',
+      jsonFormatter: 'JSON Formatter',
+      settings: 'Settings',
+      edit: 'Edit',
+      findInNotes: 'Find in Notes',
+      findInEditor: 'Find in Editor',
+      view: 'View',
+      reload: 'Reload',
+      forceReload: 'Force Reload',
+      toggleDevTools: 'Toggle Developer Tools',
+      help: 'Help',
+      checkForUpdates: 'Check for Updates',
+      about: 'About'
+    },
+    japanese: {
+      file: 'ファイル',
+      newNote: 'ノートを追加',
+      fileEditor: 'ファイルエディタ',
+      jsonFormatter: 'JSON Formatter',
+      settings: 'グローバル設定',
+      edit: '編集',
+      findInNotes: 'ノートを検索',
+      findInEditor: 'エディタ内を検索',
+      view: '表示',
+      reload: '再読み込み',
+      forceReload: '強制再読み込み',
+      toggleDevTools: '開発者ツール',
+      help: 'ヘルプ',
+      checkForUpdates: 'アップデートを確認',
+      about: 'このアプリについて'
+    }
   }
-}
 
-function buildAppMenu(language: string = 'english'): void {
-  const t = menuTranslations[language] ?? menuTranslations.english
-  const isMac = process.platform === 'darwin'
-  const template: Electron.MenuItemConstructorOptions[] = [
-    {
-      label: t.file,
-      submenu: [
-        {
-          label: t.newNote,
-          accelerator: 'CmdOrCtrl+N',
-          registerAccelerator: isMac,
-          click: () => mainWindow.webContents.send('menu-new-note')
-        },
-        {
-          label: t.fileEditor,
-          click: () => createFileEditorWindow()
-        },
-        {
-          label: t.jsonFormatter,
-          accelerator: 'CmdOrCtrl+Shift+J',
-          registerAccelerator: isMac,
-          click: () => mainWindow.webContents.send('menu-open-json-formatter')
-        },
-        { type: 'separator' },
-        {
-          label: t.settings,
-          accelerator: 'CmdOrCtrl+,',
-          registerAccelerator: isMac,
-          click: () => mainWindow.webContents.send('menu-open-settings')
-        },
-        { type: 'separator' },
-        { role: 'quit' }
-      ]
-    },
-    {
-      label: t.edit,
-      submenu: [
-        ...(isMac
-          ? [
-              { role: 'undo' as const },
-              { role: 'redo' as const },
-              { type: 'separator' as const },
-              { role: 'cut' as const },
-              { role: 'copy' as const },
-              { role: 'paste' as const },
-              { role: 'selectAll' as const },
-              { type: 'separator' as const }
-            ]
-          : []),
-        {
-          label: t.findInNotes,
-          accelerator: 'CmdOrCtrl+Shift+F',
-          registerAccelerator: isMac,
-          click: () => mainWindow.webContents.send('menu-find-in-notes')
-        },
-        {
-          label: t.findInEditor,
-          accelerator: 'CmdOrCtrl+F',
-          registerAccelerator: isMac,
-          click: () => mainWindow.webContents.send('menu-find-in-editor')
-        }
-      ]
-    },
-    {
-      label: t.view,
-      submenu: [
-        { role: 'reload', label: t.reload },
-        { role: 'forceReload', label: t.forceReload },
-        { role: 'toggleDevTools', label: t.toggleDevTools }
-      ]
-    },
-    {
-      label: t.help,
-      submenu: [
-        {
-          label: t.checkForUpdates,
-          click: () => mainWindow.webContents.send('menu-check-for-updates')
-        },
-        { type: 'separator' },
-        {
-          label: t.about,
-          click: () => mainWindow.webContents.send('menu-about')
-        }
-      ]
-    }
-  ]
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template))
-}
+  function buildAppMenu(language: string = 'english'): void {
+    const t = menuTranslations[language] ?? menuTranslations.english
+    const isMac = process.platform === 'darwin'
+    const template: Electron.MenuItemConstructorOptions[] = [
+      {
+        label: t.file,
+        submenu: [
+          {
+            label: t.newNote,
+            accelerator: 'CmdOrCtrl+N',
+            registerAccelerator: isMac,
+            click: () => mainWindow.webContents.send('menu-new-note')
+          },
+          {
+            label: t.fileEditor,
+            click: () => createFileEditorWindow()
+          },
+          {
+            label: t.jsonFormatter,
+            accelerator: 'CmdOrCtrl+Shift+J',
+            registerAccelerator: isMac,
+            click: () => mainWindow.webContents.send('menu-open-json-formatter')
+          },
+          { type: 'separator' },
+          {
+            label: t.settings,
+            accelerator: 'CmdOrCtrl+,',
+            registerAccelerator: isMac,
+            click: () => mainWindow.webContents.send('menu-open-settings')
+          },
+          { type: 'separator' },
+          { role: 'quit' }
+        ]
+      },
+      {
+        label: t.edit,
+        submenu: [
+          ...(isMac
+            ? [
+                { role: 'undo' as const },
+                { role: 'redo' as const },
+                { type: 'separator' as const },
+                { role: 'cut' as const },
+                { role: 'copy' as const },
+                { role: 'paste' as const },
+                { role: 'selectAll' as const },
+                { type: 'separator' as const }
+              ]
+            : []),
+          {
+            label: t.findInNotes,
+            accelerator: 'CmdOrCtrl+Shift+F',
+            registerAccelerator: isMac,
+            click: () => mainWindow.webContents.send('menu-find-in-notes')
+          },
+          {
+            label: t.findInEditor,
+            accelerator: 'CmdOrCtrl+F',
+            registerAccelerator: isMac,
+            click: () => mainWindow.webContents.send('menu-find-in-editor')
+          }
+        ]
+      },
+      {
+        label: t.view,
+        submenu: [
+          { role: 'reload', label: t.reload },
+          { role: 'forceReload', label: t.forceReload },
+          { role: 'toggleDevTools', label: t.toggleDevTools }
+        ]
+      },
+      {
+        label: t.help,
+        submenu: [
+          {
+            label: t.checkForUpdates,
+            click: () => mainWindow.webContents.send('menu-check-for-updates')
+          },
+          { type: 'separator' },
+          {
+            label: t.about,
+            click: () => mainWindow.webContents.send('menu-about')
+          }
+        ]
+      }
+    ]
+    Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+  }
 
-export function initAutoUpdater(mainWindow: BrowserWindow) {
-  // 開発環境では動かさない
-  if (!app.isPackaged) return
+  function initAutoUpdater(mainWindow: BrowserWindow) {
+    // 開発環境では動かさない
+    if (!app.isPackaged) return
 
-  autoUpdater.autoDownload = true // バックグラウンドで自動DL
-  autoUpdater.autoInstallOnAppQuit = true // 終了時に自動インストール
+    autoUpdater.autoDownload = true // バックグラウンドで自動DL
+    autoUpdater.autoInstallOnAppQuit = true // 終了時に自動インストール
 
-  autoUpdater.on('checking-for-update', () => {
-    mainWindow.webContents.send('update-checking')
-  })
+    autoUpdater.on('checking-for-update', () => {
+      mainWindow.webContents.send('update-checking')
+    })
 
-  autoUpdater.on('update-available', (info) => {
-    mainWindow.webContents.send('update-available', info)
-  })
+    autoUpdater.on('update-available', (info) => {
+      mainWindow.webContents.send('update-available', info)
+    })
 
-  autoUpdater.on('update-not-available', () => {
-    mainWindow.webContents.send('update-not-available')
-  })
+    autoUpdater.on('update-not-available', () => {
+      mainWindow.webContents.send('update-not-available')
+    })
 
-  autoUpdater.on('update-downloaded', (info) => {
-    mainWindow.webContents.send('update-downloaded', info)
-  })
+    autoUpdater.on('update-downloaded', (info) => {
+      mainWindow.webContents.send('update-downloaded', info)
+    })
 
-  autoUpdater.on('error', (err) => {
-    console.error('AutoUpdater error:', err)
-    mainWindow.webContents.send('update-error', err.message)
-  })
+    autoUpdater.on('error', (err) => {
+      console.error('AutoUpdater error:', err)
+      mainWindow.webContents.send('update-error', err.message)
+    })
 
-  // 起動時にチェック
-  autoUpdater.checkForUpdates()
-}
+    // 起動時にチェック
+    autoUpdater.checkForUpdates()
+  }
 
-function createWindow(): void {
-  const appStateData = dbInstance.dbs.appStateDb.data
+  function createWindow(): void {
+    const appStateData = dbInstance.dbs.appStateDb.data
 
-  const isNonMac = process.platform !== 'darwin'
+    const isNonMac = process.platform !== 'darwin'
 
-  // Create the browser window.
-  mainWindow = new BrowserWindow({
-    width: appStateData?.windowWidth != null ? appStateData?.windowWidth : 800,
-    height: appStateData?.windowHeight != null ? appStateData?.windowHeight : 600,
-    useContentSize: true,
-    show: false,
-    autoHideMenuBar: true,
-    frame: !isNonMac,
-    ...(process.platform === 'linux' ? { icon } : {}),
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.mjs'),
-      sandbox: false
-    }
-  })
-
-  buildAppMenu()
-  ipcMain.on('update-menu-language', (_, language: string) => buildAppMenu(language))
-
-  if (!isNonMac) {
-    mainWindow.webContents.on('before-input-event', (event, input) => {
-      if (input.type !== 'keyDown' || !input.meta || !input.shift) return
-      if (input.code === 'KeyF') {
-        event.preventDefault()
-        mainWindow.webContents.send('menu-find-in-notes')
+    // Create the browser window.
+    mainWindow = new BrowserWindow({
+      width: appStateData?.windowWidth != null ? appStateData?.windowWidth : 800,
+      height: appStateData?.windowHeight != null ? appStateData?.windowHeight : 600,
+      useContentSize: true,
+      show: false,
+      autoHideMenuBar: true,
+      frame: !isNonMac,
+      ...(process.platform === 'linux' ? { icon } : {}),
+      webPreferences: {
+        preload: join(__dirname, '../preload/index.mjs'),
+        sandbox: false
       }
     })
-  }
 
-  if (isNonMac) {
-    mainWindow.on('maximize', () => mainWindow.webContents.send('maximize-changed', true))
-    mainWindow.on('unmaximize', () => mainWindow.webContents.send('maximize-changed', false))
+    buildAppMenu()
+    ipcMain.on('update-menu-language', (_, language: string) => buildAppMenu(language))
 
-    ipcMain.on('popup-application-menu', () => {
-      Menu.getApplicationMenu()?.popup({ window: mainWindow })
+    if (!isNonMac) {
+      mainWindow.webContents.on('before-input-event', (event, input) => {
+        if (input.type !== 'keyDown' || !input.meta || !input.shift) return
+        if (input.code === 'KeyF') {
+          event.preventDefault()
+          mainWindow.webContents.send('menu-find-in-notes')
+        }
+      })
+    }
+
+    if (isNonMac) {
+      mainWindow.on('maximize', () => mainWindow.webContents.send('maximize-changed', true))
+      mainWindow.on('unmaximize', () => mainWindow.webContents.send('maximize-changed', false))
+
+      ipcMain.on('popup-application-menu', () => {
+        Menu.getApplicationMenu()?.popup({ window: mainWindow })
+      })
+      ipcMain.on('minimize-window', () => mainWindow.minimize())
+      ipcMain.on('maximize-window', () => {
+        mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize()
+      })
+      ipcMain.on('close-window', () => mainWindow.close())
+      ipcMain.handle('is-maximized', () => mainWindow.isMaximized())
+    }
+
+    if (appStateData.windowX != null && appStateData.windowY != null) {
+      mainWindow.setPosition(appStateData.windowX, appStateData.windowY, false)
+    } else {
+      mainWindow.center()
+    }
+
+    mainWindow.on('ready-to-show', () => {
+      console.timeLog('[startup] total', 'window visible (ready-to-show)')
+      mainWindow.show()
     })
-    ipcMain.on('minimize-window', () => mainWindow.minimize())
-    ipcMain.on('maximize-window', () => {
-      mainWindow.isMaximized() ? mainWindow.unmaximize() : mainWindow.maximize()
+
+    mainWindow.on('move', async () => {
+      const bounds = mainWindow.getBounds()
+      const appStateDb = dbInstance.dbs.appStateDb
+      appStateDb.data.windowX = bounds.x
+      appStateDb.data.windowY = bounds.y
+      await appStateDb.write()
     })
-    ipcMain.on('close-window', () => mainWindow.close())
-    ipcMain.handle('is-maximized', () => mainWindow.isMaximized())
+
+    mainWindow.webContents.setWindowOpenHandler((details) => {
+      shell.openExternal(details.url)
+      return { action: 'deny' }
+    })
+
+    mainWindow.webContents.on('did-finish-load', () => {
+      console.timeEnd('[startup] total')
+
+      // Handle files passed via command line (Windows/Linux)
+      const argv = process.argv
+      if (app.isPackaged) {
+        // In packaged apps, the first arg is the executable, the rest are files
+        const fileToOpen = argv.find((arg, i) => i > 0 && !arg.startsWith('-'))
+        if (fileToOpen) {
+          createFileEditorWindow(fileToOpen)
+        }
+      }
+
+      // Handle queued files on macOS
+      if (filesToOpen.length > 0) {
+        filesToOpen.forEach((file) => createFileEditorWindow(file))
+        filesToOpen.length = 0
+      }
+    })
+
+    // HMR for renderer base on electron-vite cli.
+    // Load the remote URL for development or the local html file for production.
+    if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+      mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
+      mainWindow.webContents.reloadIgnoringCache()
+    } else {
+      mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    }
   }
 
-  if (appStateData.windowX != null && appStateData.windowY != null) {
-    mainWindow.setPosition(appStateData.windowX, appStateData.windowY, false)
-  } else {
-    mainWindow.center()
-  }
+  // This method will be called when Electron has finished
+  // initialization and is ready to create browser windows.
+  // Some APIs can only be used after this event occurs.
+  app.whenReady().then(async () => {
+    console.timeEnd('[startup] app-ready')
+    console.time('[startup] create-window')
 
-  mainWindow.on('ready-to-show', () => {
-    console.timeLog('[startup] total', 'window visible (ready-to-show)')
-    mainWindow.show()
+    // Set app user model id for windows
+    electronApp.setAppUserModelId('me.saino.leavepad')
+
+    // Default open or close DevTools by F12 in development
+    // and ignore CommandOrControl + R in production.
+    // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
+    app.on('browser-window-created', (_, window) => {
+      optimizer.watchWindowShortcuts(window)
+    })
+
+    // IPC test
+    ipcMain.on('ping', () => console.log('pong'))
+
+    // Register file editor IPC handlers
+    registerFileEditorIpcHandles()
+    registerFileEditorWindowHandlers()
+    registerJsonFormatterWindowHandlers()
+
+    createWindow()
+    console.timeEnd('[startup] create-window')
+
+    registerIpcHandles(ipcMain, mainWindow)
+
+    initAutoUpdater(mainWindow)
+
+    app.on('activate', function () {
+      // On macOS it's common to re-create a window in the app when the
+      // dock icon is clicked and there are no other windows open.
+      if (BrowserWindow.getAllWindows().length === 0) createWindow()
+    })
   })
 
-  mainWindow.on('move', async () => {
-    const bounds = mainWindow.getBounds()
-    const appStateDb = dbInstance.dbs.appStateDb
-    appStateDb.data.windowX = bounds.x
-    appStateDb.data.windowY = bounds.y
-    await appStateDb.write()
+  // Quit when all windows are closed, except on macOS. There, it's common
+  // for applications and their menu bar to stay active until the user quits
+  // explicitly with Cmd + Q.
+  app.on('window-all-closed', async () => {
+    await dbInstance.writeAllDbs()
+    if (process.platform !== 'darwin') {
+      app.quit()
+    }
   })
-
-  mainWindow.webContents.setWindowOpenHandler((details) => {
-    shell.openExternal(details.url)
-    return { action: 'deny' }
-  })
-
-  mainWindow.webContents.on('did-finish-load', () => {
-    console.timeEnd('[startup] total')
-  })
-
-  // HMR for renderer base on electron-vite cli.
-  // Load the remote URL for development or the local html file for production.
-  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-    mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
-    mainWindow.webContents.reloadIgnoringCache()
-  } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
-  }
 }
-
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
-app.whenReady().then(async () => {
-  console.timeEnd('[startup] app-ready')
-  console.time('[startup] create-window')
-
-  // Set app user model id for windows
-  electronApp.setAppUserModelId('me.saino.leavepad')
-
-  // Default open or close DevTools by F12 in development
-  // and ignore CommandOrControl + R in production.
-  // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
-  app.on('browser-window-created', (_, window) => {
-    optimizer.watchWindowShortcuts(window)
-  })
-
-  // IPC test
-  ipcMain.on('ping', () => console.log('pong'))
-
-  // Register file editor IPC handlers
-  registerFileEditorIpcHandles()
-  registerFileEditorWindowHandlers()
-  registerJsonFormatterWindowHandlers()
-
-  createWindow()
-  console.timeEnd('[startup] create-window')
-
-  registerIpcHandles(ipcMain, mainWindow)
-
-  initAutoUpdater(mainWindow)
-
-  app.on('activate', function () {
-    // On macOS it's common to re-create a window in the app when the
-    // dock icon is clicked and there are no other windows open.
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
-  })
-})
-
-// Quit when all windows are closed, except on macOS. There, it's common
-// for applications and their menu bar to stay active until the user quits
-// explicitly with Cmd + Q.
-app.on('window-all-closed', async () => {
-  await dbInstance.writeAllDbs()
-  if (process.platform !== 'darwin') {
-    app.quit()
-  }
-})
-
-// In this file you can include the rest of your app"s specific main process
-// code. You can also put them in separate files and require them here.


### PR DESCRIPTION
- Add file associations for .txt, .md, .json, etc. in electron-builder config
- Implement single instance lock to prevent multiple app instances
- Handle file opening from second instance and macOS 'open-file' event